### PR TITLE
Add dual support for Python 2.7 and Python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,139 @@
+## Local
+
+*.lock
+
+## Github/gitignore: Language Python
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+## Github/gitignore: Editor vim
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include VERSION

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+collectd = "*"
+
+[dev-packages]
+tox = "*"
+tox-pipenv = "*"
+
+[requires]
+python_version = "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = py27, py37
 
 [testenv]
 whitelist_externals = python
-commands = python elasticsearch_collectd.py
+commands = {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27, py37
+
+[testenv]
+whitelist_externals = python
+commands = python elasticsearch_collectd.py


### PR DESCRIPTION
* Use tox, tox-pipenv for multiple version checking
* Add MANIFEST file for missing package artifacts
* Add [gitignore](https://github.com/github/gitignore) for vim and Python

And a brief overview of the actual changes made:

* Use `print_function` to ensure `print` is always used as a function instead of
  a statement
* Use Python 3-compatible urllib imports
* Fix uses for `dict.keys`, `dict.values` and `dict.iteritems` to make all
  usages compatible with Python 2 and 3
* Fix string mangling for index names to be compatible with Python 3 bytes

If you have Python 2.7 and Python 3.7 already installed on your system, you can
quickly make sure that both versions work for you like this:

```
tox -- python elasticsearch_collectd.py localhost:9200
```